### PR TITLE
Correcting requirement of Access Key and Secret Key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.upplication.maven.plugins</groupId>
     <artifactId>s3-download-maven-plugin</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.3-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>S3 download maven plugin</name>
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.3.26</version>
+            <version>1.9.6</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.upplication.maven.plugins</groupId>
     <artifactId>s3-download-maven-plugin</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.4-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>S3 download maven plugin</name>

--- a/readme.md
+++ b/readme.md
@@ -10,8 +10,8 @@ Configuration parameters
 |bucketName|The name of the bucket|*yes*| |
 |source|The source amazon s3 file key. Empty to download the whole bucket.|*no*| |
 |destination|The destination file or destination folder. Directories *MUST* end with */*| *yes*| |
-|accessKey|S3 access key | *yes* | if unspecified, uses the Default Provider, falling back to env variables |
-|secretKey|S3 secret key | *yes* | if unspecified, uses the Default Provider, falling back to env variables |
+|accessKey|S3 access key | *no* | if unspecified, uses the Default Provider, falling back to env variables |
+|secretKey|S3 secret key | *no* | if unspecified, uses the Default Provider, falling back to env variables |
 |endpoint|Use a different s3 endpoint| *no* | s3.amazonaws.com |
 
 Example: Download a bucket

--- a/src/main/java/com/upplication/maven/plugins/s3/download/S3DownloadMojo.java
+++ b/src/main/java/com/upplication/maven/plugins/s3/download/S3DownloadMojo.java
@@ -24,13 +24,13 @@ public class S3DownloadMojo extends AbstractMojo {
     /**
      * Access key for S3.
      */
-    @Parameter(property = "s3-download.accessKey", required = true)
+    @Parameter(property = "s3-download.accessKey")
     private String accessKey;
 
     /**
      * Secret key for S3.
      */
-    @Parameter(property = "s3-download.secretKey", required = true)
+    @Parameter(property = "s3-download.secretKey")
     private String secretKey;
 
     /**


### PR DESCRIPTION
Updated the SDK from AWS and removed the requirement for Access Key and Secret Key on the pom.